### PR TITLE
refactor: optimized def_unit_dyn_app_error

### DIFF
--- a/src-tauri/improvie-app/src/model/dialog.rs
+++ b/src-tauri/improvie-app/src/model/dialog.rs
@@ -1,14 +1,11 @@
 use std::path::PathBuf;
 
-use improvie_logic::{impl_serialize_for_dyn_app_error, impl_unit_dyn_app_error};
+use improvie_logic::def_unit_dyn_app_error;
 use tauri_plugin_dialog::FilePath;
 
-#[derive(Debug, thiserror::Error)]
-#[error("Not allow url on file dialog")]
-pub struct NotAllowUrlOnFileDialog;
-
-impl_unit_dyn_app_error!(NotAllowUrlOnFileDialog);
-impl_serialize_for_dyn_app_error!(NotAllowUrlOnFileDialog);
+def_unit_dyn_app_error! {
+    pub struct NotAllowUrlOnFileDialog = "Not allow url on file dialog";
+}
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub enum FileDialogKind {

--- a/src-tauri/improvie-logic/src/error.rs
+++ b/src-tauri/improvie-logic/src/error.rs
@@ -45,20 +45,29 @@ where
 
 mod macros {
     #[macro_export]
-    macro_rules! impl_unit_dyn_app_error {
-        ($error:ident) => {
-            impl $crate::DynAppError for $error {
+    macro_rules! def_unit_dyn_app_error {
+        (
+            $(#[$attr:meta])*
+            $vis:vis struct $ident:ident = $error:literal;
+        ) => {
+            #[derive(Debug)] $(#[$($attr)*])*
+            $vis struct $ident;
+
+            impl $crate::DynAppError for $ident {
                 fn error_kind(&self) -> &'static str {
-                    stringify!($error)
+                    stringify!($ident)
                 }
             }
-        };
-        ($error:ident, $kind:literal) => {
-            impl $crate::DynAppError for $error {
-                fn error_kind(&self) -> &'static str {
-                    $kind
+
+            impl std::error::Error for $ident {}
+
+            impl std::fmt::Display for $ident {
+                fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    formatter.write_str($error)
                 }
             }
+
+            $crate::impl_serialize_for_dyn_app_error!($ident);
         };
     }
 


### PR DESCRIPTION
unit errorの定義に必要なのはidentとerror messageだけなのでそれらだけを必要とするように修正